### PR TITLE
Php backward branch

### DIFF
--- a/third_party/MX/Config.php
+++ b/third_party/MX/Config.php
@@ -42,8 +42,16 @@ class MX_Config extends CI_Config
         }
 
         $_module or $_module = CI::$APP->router->fetch_module();
+        
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0. 
+     if (version_compare(phpversion(), '7.1', '<')) {
+        // php version isn't high enough
         list($path, $file) = Modules::find($file, $_module, 'config/');
-
+    } else {
+        [$path, $file] = Modules::find($file, $_module, 'config/');
+    }
+        
         if ($path === false) {
             parent::load($file, $use_sections, $fail_gracefully);
             return $this->item($file);

--- a/third_party/MX/Config.php
+++ b/third_party/MX/Config.php
@@ -42,16 +42,16 @@ class MX_Config extends CI_Config
         }
 
         $_module or $_module = CI::$APP->router->fetch_module();
-        
+
         // Backward function
-        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0. 
-     if (version_compare(phpversion(), '7.1', '<')) {
-        // php version isn't high enough
-        list($path, $file) = Modules::find($file, $_module, 'config/');
-    } else {
-        [$path, $file] = Modules::find($file, $_module, 'config/');
-    }
-        
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $file) = Modules::find($file, $_module, 'config/');
+        } else {
+            [$path, $file] = Modules::find($file, $_module, 'config/');
+        }
+
         if ($path === false) {
             parent::load($file, $use_sections, $fail_gracefully);
             return $this->item($file);

--- a/third_party/MX/Modules.php
+++ b/third_party/MX/Modules.php
@@ -80,14 +80,21 @@ class Modules
     /** Load a module controller **/
     public static function load($module)
     {
-        if (!is_array($module)) {
-            $params = null;
+        // Backward function
+        // The function each() has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged
+        if (version_compare(phpversion(), '7.2', '<')) {
+            // php version isn't high enough
+            (is_array($module)) ? list($module, $params) = each($module) : $params = null;
         } else {
-            $keys = array_keys($module);
+            if (!is_array($module)) {
+                $params = null;
+            } else {
+                $keys = array_keys($module);
 
-            $params = $module[$keys[0]];
+                $params = $module[$keys[0]];
 
-            $module = $keys[0];
+                $module = $keys[0];
+            }
         }
 
         /* get the requested controller class name */


### PR DESCRIPTION
Backward function for each() and list() added.

- The each() function has been DEPRECATED as of PHP 7.2.0. Relying on this function is highly discouraged.

-  In PHP 5, list() assigns the values starting with the right-most parameter. In PHP 7, list() starts with the left-most parameter.