### PR TITLE
Php backward branch

### DIFF
--- a/third_party/MX/Lang.php
+++ b/third_party/MX/Lang.php
@@ -52,7 +52,15 @@ class MX_Lang extends CI_Lang
         }
 
         $_module or $_module = CI::$APP->router->fetch_module();
-        list($path, $_langfile) = Modules::find($langfile.'_lang', $_module, 'language/'.$idiom.'/');
+
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $_langfile) = Modules::find($langfile.'_lang', $_module, 'language/'.$idiom.'/');
+        } else {
+            [$path, $_langfile] = Modules::find($langfile.'_lang', $_module, 'language/'.$idiom.'/');
+        }
 
         if ($path === false) {
             if ($lang = parent::load($langfile, $lang, $return, $add_suffix, $alt_path)) {

--- a/third_party/MX/Loader.php
+++ b/third_party/MX/Loader.php
@@ -117,8 +117,14 @@ class MX_Loader extends CI_Loader
         if (isset($this->_ci_helpers[$helper])) {
             return;
         }
-
-        list($path, $_helper) = Modules::find($helper.'_helper', $this->_module, 'helpers/');
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $_helper) = Modules::find($helper.'_helper', $this->_module, 'helpers/');
+        } else {
+            [$path, $_helper] = Modules::find($helper.'_helper', $this->_module, 'helpers/');
+        }
 
         if ($path === false) {
             return parent::helper($helper);
@@ -168,11 +174,26 @@ class MX_Loader extends CI_Loader
 
         ($_alias = strtolower($object_name)) or $_alias = $class;
 
-        list($path, $_library) = Modules::find($library, $this->_module, 'libraries/');
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $_library) = Modules::find($library, $this->_module, 'libraries/');
+        } else {
+            [$path, $_library] = Modules::find($library, $this->_module, 'libraries/');
+        }
 
         /* load library config file as params */
         if ($params == null) {
-            list($path2, $file) = Modules::find($_alias, $this->_module, 'config/');
+
+            // Backward function
+            // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+            if (version_compare(phpversion(), '7.1', '<')) {
+                // php version isn't high enough
+                list($path2, $file) = Modules::find($_alias, $this->_module, 'config/');
+            } else {
+                [$path2, $file] = Modules::find($_alias, $this->_module, 'config/');
+            }
             ($path2) && $params = Modules::load_file($file, $path2, 'config');
         }
 
@@ -211,8 +232,15 @@ class MX_Loader extends CI_Loader
             return $this;
         }
 
-        /* check module */
-        list($path, $_model) = Modules::find(strtolower($model), $this->_module, 'models/');
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            /* check module */
+            list($path, $_model) = Modules::find(strtolower($model), $this->_module, 'models/');
+        } else {
+            [$path, $_model] = Modules::find(strtolower($model), $this->_module, 'models/');
+        }
 
         if ($path == false) {
             /* check application & packages */
@@ -278,7 +306,14 @@ class MX_Loader extends CI_Loader
             return $this;
         }
 
-        list($path, $_plugin) = Modules::find($plugin.'_pi', $this->_module, 'plugins/');
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $_plugin) = Modules::find($plugin.'_pi', $this->_module, 'plugins/');
+        } else {
+            [$path, $_plugin] = Modules::find($plugin.'_pi', $this->_module, 'plugins/');
+        }
 
         if ($path === false && ! is_file($_plugin = APPPATH.'plugins/'.$_plugin.EXT)) {
             show_error("Unable to locate the plugin file: {$_plugin}");
@@ -395,14 +430,28 @@ class MX_Loader extends CI_Loader
         $path = false;
 
         if ($this->_module) {
-            list($path, $file) = Modules::find('constants', $this->_module, 'config/');
 
+        // Backward function
+            // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+            if (version_compare(phpversion(), '7.1', '<')) {
+                // php version isn't high enough
+                list($path, $file) = Modules::find('constants', $this->_module, 'config/');
+            } else {
+                [$path, $file] = Modules::find('constants', $this->_module, 'config/');
+            }
             /* module constants file */
             if ($path != false) {
                 include_once $path.$file.EXT;
             }
 
-            list($path, $file) = Modules::find('autoload', $this->_module, 'config/');
+            // Backward function
+            // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+            if (version_compare(phpversion(), '7.1', '<')) {
+                // php version isn't high enough
+                list($path, $file) = Modules::find('autoload', $this->_module, 'config/');
+            } else {
+                [$path, $file] = Modules::find('autoload', $this->_module, 'config/');
+            }
 
             /* module autoload file */
             if ($path != false) {

--- a/third_party/MX/Loader.php
+++ b/third_party/MX/Loader.php
@@ -301,7 +301,14 @@ class MX_Loader extends CI_Loader
     /** Load a module view **/
     public function view($view, $vars = array(), $return = false)
     {
-        list($path, $_view) = Modules::find($view, $this->_module, 'views/');
+        // Backward function
+        // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+        if (version_compare(phpversion(), '7.1', '<')) {
+            // php version isn't high enough
+            list($path, $_view) = Modules::find($view, $this->_module, 'views/');
+        } else {
+            [$path, $_view] = Modules::find($view, $this->_module, 'views/');
+        }
 
         if ($path != false) {
             $this->_ci_view_paths = array($path => true) + $this->_ci_view_paths;

--- a/third_party/MX/Modules.php
+++ b/third_party/MX/Modules.php
@@ -102,9 +102,17 @@ class Modules
         $alias = strtolower(basename($module));
 
         /* create or return an existing controller from the registry */
-        if (! isset(self::$registry[$alias])) {
-            /* find the controller */
-            list($class) = CI::$APP->router->locate(explode('/', $module));
+        if (!isset(self::$registry[$alias])) {
+
+        // Backward function
+            // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+            if (version_compare(phpversion(), '7.1', '<')) {
+                // php version isn't high enough
+                /* find the controller */
+                list($class) = CI::$APP->router->locate(explode('/', $module));
+            } else {
+                [$class] = CI::$APP->router->locate(explode('/', $module));
+            }
 
             /* controller cannot be located */
             if (empty($class)) {
@@ -225,8 +233,18 @@ class Modules
     {
         /* load the route file */
         if (! isset(self::$routes[$module])) {
-            if (list($path) = self::find('routes', $module, 'config/')) {
-                $path && self::$routes[$module] = self::load_file('routes', $path, 'route');
+
+        // Backward function
+            // Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.
+            if (version_compare(phpversion(), '7.1', '<')) {
+                // php version isn't high enough
+                if (list($path) = self::find('routes', $module, 'config/')) {
+                    $path && self::$routes[$module] = self::load_file('routes', $path, 'route');
+                }
+            } else {
+                if ([$path] = self::find('routes', $module, 'config/')) {
+                    $path && self::$routes[$module] = self::load_file('routes', $path, 'route');
+                }
             }
         }
 


### PR DESCRIPTION
Backward function for list()

- Before PHP 7.1.0, list() only worked on numerical arrays and assumes the numerical indices start at 0.